### PR TITLE
more tolerant behavior on empty token

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.rabbitmqbuildtrigger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.Extension;
@@ -102,6 +103,12 @@ public class RemoteBuildListener implements ExtensionPoint, ApplicationMessageLi
     public void onReceive(String queueName, JSONObject json) {
         synchronized (lock) {
             for (RemoteBuildTrigger t : triggers) {
+
+                if (t.getRemoteBuildToken() == null) {
+                    LOGGER.log(Level.WARNING, "ignoring AMQP trigger for project {0}: no token set", t.getProjectName());
+                    continue;
+                }
+
                 if (t.getProjectName().equals(json.getString(KEY_PROJECT))
                         && t.getRemoteBuildToken().equals(json.getString(KEY_TOKEN))) {
                     t.scheduleBuild(queueName, json.getJSONArray(KEY_PARAMETER));


### PR DESCRIPTION
Currently, any project that has rabbitmq-build-trigger enabled but no token set throws a NullPointerException. This is particularly bad as it affects all projects using this plugin and may even terminate the RabbitMQ connection.

This patch catches the NPE and logs a warning.
