### PR TITLE
bug fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
@@ -43,6 +43,15 @@ public class RemoteBuildListener extends MessageQueueListener {
     }
 
     /**
+     * Get triggers.
+     *
+     *       the triggers.
+     */
+    public  Set<RemoteBuildTrigger> getTriggers(){
+        return this.triggers;
+    }
+    
+    /**
      * Adds trigger.
      *
      * @param trigger

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -63,7 +63,7 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     @Override
     public void start(AbstractProject<?, ?> project, boolean newInstance) {
         RemoteBuildListener listener = MessageQueueListener.all().get(RemoteBuildListener.class);
-        
+
         if (listener != null) {
             listener.addTrigger(this);
         }

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -14,7 +14,11 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
@@ -59,11 +63,12 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     @Override
     public void start(AbstractProject<?, ?> project, boolean newInstance) {
         RemoteBuildListener listener = MessageQueueListener.all().get(RemoteBuildListener.class);
-
+        
         if (listener != null) {
             listener.addTrigger(this);
         }
         super.start(project, newInstance);
+        removeDuplicatedTrigger(listener.getTriggers());
     }
 
     @Override
@@ -72,6 +77,21 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super.stop();
     }
 
+    /**
+     * Remove the duplicated trigger from the triggers.
+     *
+     * @param triggers 
+     *          the set of current trigger instances which have already been loaded in the memory 
+     */
+    public void removeDuplicatedTrigger(Set<RemoteBuildTrigger> triggers){
+        Map<String,RemoteBuildTrigger>  tempHashMap= new HashMap<String,RemoteBuildTrigger>(); 
+        for(RemoteBuildTrigger trigger:triggers){
+            tempHashMap.put(trigger.getProjectName(), trigger);
+        }    
+        triggers.clear();
+        triggers.addAll(tempHashMap.values());
+    }
+    
     /**
      * Gets token.
      *


### PR DESCRIPTION
Backgroud:
When I was using the “Job DSL Plugin” to update the config of Jenkins,the rabbitmq-build-trigger-plugin occur to trigger the job twice but only with one message.
Read Log:
By looking into the log,I found that the "start"  function in the "RemoteBuildTrigger" Class was called when the  “Job DSL Plugin”  was updating the config of Jenkins.So it produce another "RemoteBuildTrigger" instance but the instance has the same project name with the one before updating the config by the “Job DSL Plugin”.
Conclusion:
It should consider the case that the "start"  function in the "RemoteBuildTrigger" Class  is called but it was result from the restarting of Jenkins.Because this could possibly produce duplicated triggers for one job.
![log](https://cloud.githubusercontent.com/assets/6299886/10557586/9da7c50e-74e5-11e5-95a4-04d90a22e4e1.png)
