### PR TITLE
bug fix:web page crash and configuration cannot be saved

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
@@ -43,6 +43,15 @@ public class RemoteBuildListener extends MessageQueueListener {
     }
 
     /**
+     * Get triggers.
+     *
+     *       the triggers.
+     */
+    public  Set<RemoteBuildTrigger> getTriggers(){
+        return this.triggers;
+    }
+    
+    /**
      * Adds trigger.
      *
      * @param trigger

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
@@ -29,6 +29,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * The extension publish build result using rabbitmq.

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
@@ -52,6 +52,8 @@ public class RemoteBuildPublisher extends Notifier {
 
     /**
      * Creates instance with specified parameters.
+     * @param brokerName
+     * @param routingKey
      */
     @DataBoundConstructor
     public RemoteBuildPublisher(String brokerName, String routingKey) {
@@ -81,6 +83,24 @@ public class RemoteBuildPublisher extends Notifier {
         this.brokerName = brokerName;
     }
 
+    /**
+     * Gets routingKey.
+     *
+     * @return the routingKey.
+     */
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
+    /**
+     * Sets routingKey.
+     *
+     * @param routingKey the routingKey.
+     */
+    public void setRoutingKey(String routingKey) {
+        this.routingKey = routingKey;
+    } 
+    
     /**
      * @inheritDoc
      */
@@ -155,7 +175,17 @@ public class RemoteBuildPublisher extends Notifier {
      */
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-
+        public DescriptorImpl() {
+            super(RemoteBuildPublisher.class);
+            load();
+        }
+    
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData){              
+            save();
+            return true;
+        }
+        
         /**
          * @inheritDoc
          */

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -63,7 +63,7 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     @Override
     public void start(AbstractProject<?, ?> project, boolean newInstance) {
         RemoteBuildListener listener = MessageQueueListener.all().get(RemoteBuildListener.class);
-        
+
         if (listener != null) {
             listener.addTrigger(this);
         }

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -14,7 +14,11 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
@@ -59,11 +63,12 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     @Override
     public void start(AbstractProject<?, ?> project, boolean newInstance) {
         RemoteBuildListener listener = MessageQueueListener.all().get(RemoteBuildListener.class);
-
+        
         if (listener != null) {
             listener.addTrigger(this);
         }
         super.start(project, newInstance);
+        removeDuplicatedTrigger(listener.getTriggers());
     }
 
     @Override
@@ -72,6 +77,21 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super.stop();
     }
 
+    /**
+     * Remove the duplicated trigger from the triggers.
+     *
+     * @param triggers 
+     *          the set of current trigger instances which have already been loaded in the memory 
+     */
+    public void removeDuplicatedTrigger(Set<RemoteBuildTrigger> triggers){
+        Map<String,RemoteBuildTrigger>  tempHashMap= new HashMap<String,RemoteBuildTrigger>(); 
+        for(RemoteBuildTrigger trigger:triggers){
+            tempHashMap.put(trigger.getProjectName(), trigger);
+        }    
+        triggers.clear();
+        triggers.addAll(tempHashMap.values());
+    }
+    
     /**
      * Gets token.
      *

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -116,7 +116,10 @@ public class RemoteBuildTrigger extends Trigger<AbstractProject<?, ?>> {
      * @return the project name.
      */
     public String getProjectName() {
-        return job.getName();
+        if(job!=null){
+            return job.getName();
+        }
+        return "";
     }
 
     /**


### PR DESCRIPTION
1、The configuration of the routing key of one job which was configured with publisher section cannot be saved.This is resulted from the RemoteBuildPublisher class lacking of the setter and getter methods. 
2、When the configuration of the RabbitMQ Build Trigger of one job which was configured with trigger section was saved by clicking,the web page will be crashed.This is because of the “job” variables   of RemoteBuildTrigger class  may be null.So I add an NullPointerException protection to the method getProjectName.