### PR TITLE
Add annotation "Symbol" as "remoteBuild"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <jmockit.version>1.5</jmockit.version>
     <junit.version>4.11</junit.version>
     <rabbitmq.consumer.version>2.5</rabbitmq.consumer.version>
+    <structs.version>1.10</structs.version>
     <commons.lang3.version>3.6</commons.lang3.version>
   </properties>
 
@@ -67,6 +68,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>rabbitmq-consumer</artifactId>
       <version>${rabbitmq.consumer.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>${structs.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.commons</groupId>

--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -10,11 +10,4 @@
         <Method name="RabbitMQBuildTrigger" />
         <Bug pattern="NM_METHOD_NAMING_CONVENTION" />
     </Match>
-
-    <!-- CN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE -->
-    <Match>
-        <Class name="org.jenkinsci.plugins.rabbitmqbuildtrigger.RemoteBuildPublisher" />
-        <Method name="perform" />
-        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-    </Match>
 </FindBugsFilter>

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
@@ -156,24 +156,22 @@ public class RemoteBuildPublisher extends Notifier {
         // Publish message
         PublishChannel ch = PublishChannelFactory.getPublishChannel();
         if (ch != null && ch.isOpen()) {
-            if (brokerName != null) {
-                // return value is not needed if you don't need to wait.
-                Future<PublishResult> future = ch.publish(brokerName, routingKey, builder.build(),
-                                                          json.toString().getBytes(StandardCharsets.UTF_8));
+            // return value is not needed if you don't need to wait.
+            Future<PublishResult> future = ch.publish(brokerName, routingKey, builder.build(),
+                                                      json.toString().getBytes(StandardCharsets.UTF_8));
 
-                // Wait until publish is completed.
-                try {
-                    PublishResult result = future.get();
+            // Wait until publish is completed.
+            try {
+                PublishResult result = future.get();
 
-                    if (result.isSuccess()) {
-                        listener.getLogger().println(LOG_HEADER + "Success.");
-                    } else {
-                        listener.getLogger().println(LOG_HEADER + "Fail - " + result.getMessage());
-                    }
-                } catch (Exception e) {
-                    LOGGER.warning(e.getMessage());
-                    listener.getLogger().println(LOG_HEADER + "Fail due to exception.");
+                if (result.isSuccess()) {
+                    listener.getLogger().println(LOG_HEADER + "Success.");
+                } else {
+                    listener.getLogger().println(LOG_HEADER + "Fail - " + result.getMessage());
                 }
+            } catch (Exception e) {
+                LOGGER.warning(e.getMessage());
+                listener.getLogger().println(LOG_HEADER + "Fail due to exception.");
             }
         }
         return true;

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.jenkinsci.plugins.rabbitmqbuildtrigger;
 
 import java.io.IOException;
@@ -54,8 +51,9 @@ public class RemoteBuildPublisher extends Notifier {
 
     /**
      * Creates instance with specified parameters.
-     * @param brokerName
-     * @param routingKey
+     *
+     * @param brokerName the broker name.
+     * @param routingKey the routing key.
      */
     @DataBoundConstructor
     public RemoteBuildPublisher(String brokerName, String routingKey) {
@@ -107,6 +105,7 @@ public class RemoteBuildPublisher extends Notifier {
      * Gets result as string.
      *
      * @param result the result.
+     * @return the result string.
      */
     private String getResultAsString(Result result) {
         String retStr = "ONGOING";

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
@@ -117,14 +117,15 @@ public class RemoteBuildPublisher extends Notifier {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
@@ -180,7 +181,7 @@ public class RemoteBuildPublisher extends Notifier {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public DescriptorImpl getDescriptor() {
@@ -196,7 +197,7 @@ public class RemoteBuildPublisher extends Notifier {
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         /**
-         * @inheritDoc
+         * {@inheritDoc}
          */
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> project) {
@@ -204,7 +205,7 @@ public class RemoteBuildPublisher extends Notifier {
         }
 
         /**
-         * @inheritDoc
+         * {@inheritDoc}
          */
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -28,6 +28,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.rabbitmqconsumer.extensions.MessageQueueListener;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -201,7 +202,7 @@ public class RemoteBuildTrigger<T extends Job<?, ?> & ParameterizedJobMixIn.Para
      *
      * @author rinrinne a.k.a. rin_ne
      */
-    @Extension
+    @Extension @Symbol("remoteBuild")
     public static class DescriptorImpl extends TriggerDescriptor {
 
         @Override


### PR DESCRIPTION
This patch adds annotation "Symbol" to TriggerDescriptor.
This has ability to use this in declarative pipeline script
as "remoteBuild" trigger. e.g.

```
pipeline {
  triggers {
    remoteBuild('<TOKEN>')
  }
}
```