### PR TITLE
Allow regular expressions for project names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Application Message Format
 
 ```json
 {
-    "project": "RPROJECTNAME",
+    "project": "PROJECTNAME",
     "token": "TOKEN",
     "parameter": [
         {
@@ -56,13 +56,21 @@ Application Message Format
             "name": "PARAMETERNAME2",
             "value": "VALUE2"
         }
-    ]
+    ],
+    "reason": "because I said so!"
 }
 ```
 
-name in each parameters is compared with existing parameter name by case-insensitive.
+"project" can is a regular expression that needs to match the target project's full name.
 
-A message must have two properties.
+"project" and "token" is mandatory.
+
+"parameter" entries will be passed to the triggered project(s) as job parameters, matching the
+job parameter name case-insensitively.
+
+"reason" allows an optional reason to be included in the BuildCause.
+
+A message must have two rabbit-mq properties:
 
 ```
 content_type: application/json

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,19 @@
     </developer>
   </developers>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
     <jenkins.version>1.625</jenkins.version>

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildCause.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildCause.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.rabbitmqbuildtrigger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.export.Exported;
 
 import hudson.model.Cause;
@@ -11,22 +12,28 @@ import hudson.model.Cause;
  */
 public class RemoteBuildCause extends Cause {
 
-    private final String queueName;
+    private String queueName;
+
+    private String reason;
 
     /**
-     * Creates instance with specified parameter.
+     * Creates a new cause with the given queue.
      * 
      * @param queueName
      *            the queue name.
      */
     public RemoteBuildCause(String queueName) {
+        this(queueName, null);
+    }
+
+    public RemoteBuildCause(String queueName, String reason) {
         this.queueName = queueName;
+        this.reason = StringUtils.isNotBlank(reason) ? " (" + reason + ")" : StringUtils.EMPTY;
     }
 
     @Override
     @Exported(visibility = 3)
     public String getShortDescription() {
-        return "Triggered by remote build message from RabbitMQ queue: " + queueName;
+        return "Triggered RabbitMQ message on queue: " + queueName + reason;
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildPublisher.java
@@ -117,14 +117,14 @@ public class RemoteBuildPublisher extends Notifier {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
@@ -180,7 +180,7 @@ public class RemoteBuildPublisher extends Notifier {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public DescriptorImpl getDescriptor() {
@@ -196,7 +196,7 @@ public class RemoteBuildPublisher extends Notifier {
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         /**
-         * @inheritDoc
+         * {@inheritDoc}
          */
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> project) {
@@ -204,7 +204,7 @@ public class RemoteBuildPublisher extends Notifier {
         }
 
         /**
-         * @inheritDoc
+         * {@inheritDoc}
          */
         @Override
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -1,35 +1,20 @@
 package org.jenkinsci.plugins.rabbitmqbuildtrigger;
 
 import hudson.Extension;
-import hudson.model.Item;
-import hudson.model.ParameterValue;
-import hudson.model.CauseAction;
-import hudson.model.ParameterDefinition;
-import hudson.model.ParametersAction;
-import hudson.model.ParametersDefinitionProperty;
-import hudson.model.Project;
-import hudson.model.Job;
-import hudson.model.StringParameterValue;
+import hudson.model.*;
 import hudson.model.listeners.ItemListener;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
-
 import jenkins.model.ParameterizedJobMixIn;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.rabbitmqconsumer.extensions.MessageQueueListener;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * The extension trigger builds by application message.


### PR DESCRIPTION
This allows, for example for one Jenkins to trigger multiple Jenkins instances on a change of a certain project.

Also, added an optional reason in the message to include in the BuildCause