### PR TITLE
Added support for comma separated list of build triggers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildListener.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.rabbitmqbuildtrigger;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -99,8 +100,10 @@ public class RemoteBuildListener extends MessageQueueListener {
                             continue;
                         }
 
+                        String[] remoteBuildTokens = t.getRemoteBuildToken().split(",");
+
                         if (t.getProjectName().equals(json.getString(KEY_PROJECT))
-                                && t.getRemoteBuildToken().equals(json.getString(KEY_TOKEN))) {
+                                && Arrays.asList(remoteBuildTokens).contains(json.getString(KEY_TOKEN))) {
                             if (json.containsKey(KEY_PARAMETER)) {
                                 t.scheduleBuild(queueName, json.getJSONArray(KEY_PARAMETER));
                             } else {


### PR DESCRIPTION
This adds support for listening to multiple rabbit mq triggers within the same project by using a comma seperated list.

This change is in order to provide similar support as the `upstream` trigger has, as described in https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Trigger-runs#other-available-triggers

See `upstream 'project-name,other-project-name', hudson.model.Result.SUCCESS` which allows a comma seperated list of multiple upstream projects